### PR TITLE
Fix tags of "Publishing Node.js packages"

### DIFF
--- a/content/actions/index.md
+++ b/content/actions/index.md
@@ -162,7 +162,7 @@ versions:
           <h4>Publishing Node.js packages</h4>
           <p class="mt-2 mb-4">Use GitHub Actions to push your Node.js package to GitHub Packages or npm.</p>
           <div class="d-flex">
-            <span class="IssueLabel text-white bg-blue mr-2">Java</span>
+            <span class="IssueLabel text-white bg-blue mr-2">JavaScript/TypeScript</span>
             <span class="IssueLabel text-white bg-blue mr-2">CI</span>
           </div>
         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The "Publishing Node.js packages" section contains the "Java" tag. Which is not correct.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

The tag of "Publishing Node.js packages" section from "Java" to "JavaScript/TypeScript".

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
